### PR TITLE
feat(research-mcp): expose service toggles via cli

### DIFF
--- a/packages/mcp-servers/research-mcp/README.md
+++ b/packages/mcp-servers/research-mcp/README.md
@@ -23,8 +23,26 @@ external sinks. Cached artefacts live under `RESEARCH_MCP_CACHE_DIR` (defaults t
 ## Local development
 
 ```bash
-uvicorn research_mcp.app:create_app --factory --reload --port 8081
+python -m research_mcp --reload --port 8081
 ```
+
+Additional flags mirror uvicorn options and can also be supplied via environment variables,
+e.g. `RESEARCH_MCP_PORT`, `RESEARCH_MCP_RELOAD`, `RESEARCH_MCP_PROXY_HEADERS`, and
+`RESEARCH_MCP_ROOT_PATH`. Service-specific toggles are available directly on the CLI as
+well:
+
+```bash
+python -m research_mcp \
+  --allowlist example.com,strategy.example \
+  --blocklist tracker.invalid \
+  --enable-network \
+  --use-playwright
+```
+
+The command above configures crawler allow/block lists, enables outbound requests for
+metasearch/crawling, and turns on Playwright rendering. The same options can be provided
+via `RESEARCH_MCP_ALLOWLIST`, `RESEARCH_MCP_BLOCKLIST`, `RESEARCH_MCP_ENABLE_NETWORK`,
+and `RESEARCH_MCP_USE_PLAYWRIGHT`.
 
 Run tests via `pytest` in this package (`make test` at repo root runs them automatically).
 

--- a/packages/mcp-servers/research-mcp/main.py
+++ b/packages/mcp-servers/research-mcp/main.py
@@ -1,21 +1,7 @@
-"""research-mcp stub entrypoint.
-TODO: Implement MCP server with tools: metasearch, crawl.
-"""
+"""Console entrypoint for the Research MCP server."""
 
-import argparse
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        prog="research-mcp", description="Research MCP server (stub)"
-    )
-    parser.add_argument("--port", type=int, default=8001, help="Port to listen on")
-    args = parser.parse_args()
-    print(
-        f"[research-mcp] Stub server would start on port {args.port} "
-        "(TODO[SP2-210]: launch uvicorn create_app(); see docs/backlog.md#todo-sp2-210-research-mcp-clibootstrap)"
-    )
+from research_mcp.cli import main as cli_main
 
 
 if __name__ == "__main__":
-    main()
+    cli_main()

--- a/packages/mcp-servers/research-mcp/src/research_mcp/__main__.py
+++ b/packages/mcp-servers/research-mcp/src/research_mcp/__main__.py
@@ -1,9 +1,5 @@
-import uvicorn
-
-
-def main():
-    uvicorn.run("research_mcp.app:create_app", factory=True, host="0.0.0.0", port=8081)
+from .cli import main as cli_main
 
 
 if __name__ == "__main__":
-    main()
+    cli_main()

--- a/packages/mcp-servers/research-mcp/src/research_mcp/cli.py
+++ b/packages/mcp-servers/research-mcp/src/research_mcp/cli.py
@@ -1,0 +1,213 @@
+"""Command-line interface for launching the Research MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any, Iterable, Sequence
+
+import uvicorn
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8081
+LOG_LEVEL_CHOICES = ("critical", "error", "warning", "info", "debug", "trace")
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_DEFAULT_ALLOWLIST = ("example.com",)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise SystemExit(
+            f"Environment variable {name} must be an integer, got {value!r}"
+        ) from exc
+
+
+def _env_list(name: str, default: Iterable[str]) -> list[str]:
+    value = os.getenv(name)
+    if value is None:
+        return [item for item in default]
+    return _split_domains([value])
+
+
+def _split_domains(values: Iterable[str]) -> list[str]:
+    domains: list[str] = []
+    for value in values:
+        for part in value.split(","):
+            part = part.strip()
+            if part:
+                domains.append(part)
+    return domains
+
+
+def _format_domains(domains: Iterable[str]) -> str:
+    return ",".join(domains)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser used by :func:`main`."""
+
+    parser = argparse.ArgumentParser(
+        prog="research-mcp",
+        description="Run the Research MCP FastAPI application.",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("RESEARCH_MCP_HOST", DEFAULT_HOST),
+        help="Host interface to bind (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=_env_int("RESEARCH_MCP_PORT", DEFAULT_PORT),
+        help="Port to bind (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--reload",
+        dest="reload",
+        action="store_true",
+        help="Enable autoreload. Use for local development only.",
+    )
+    parser.add_argument(
+        "--no-reload",
+        dest="reload",
+        action="store_false",
+        help="Disable autoreload (default).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.getenv("RESEARCH_MCP_LOG_LEVEL", "info"),
+        choices=LOG_LEVEL_CHOICES,
+        help="Log level for uvicorn (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=_env_int("RESEARCH_MCP_WORKERS", 1),
+        help="Number of worker processes. Ignored when reload is enabled.",
+    )
+    parser.add_argument(
+        "--proxy-headers",
+        dest="proxy_headers",
+        action="store_true",
+        help="Enable proxy headers support (X-Forwarded-For, etc.).",
+    )
+    parser.add_argument(
+        "--no-proxy-headers",
+        dest="proxy_headers",
+        action="store_false",
+        help="Disable proxy headers (default).",
+    )
+    parser.add_argument(
+        "--root-path",
+        default=os.getenv("RESEARCH_MCP_ROOT_PATH"),
+        help="ASGI root_path when served behind a reverse proxy.",
+    )
+    parser.set_defaults(
+        reload=_env_flag("RESEARCH_MCP_RELOAD", False),
+        proxy_headers=_env_flag("RESEARCH_MCP_PROXY_HEADERS", False),
+        enable_network=_env_flag("RESEARCH_MCP_ENABLE_NETWORK", False),
+        use_playwright=_env_flag("RESEARCH_MCP_USE_PLAYWRIGHT", False),
+    )
+
+    service_group = parser.add_argument_group(
+        "service options",
+        "Configure Research MCP integrations (applied via environment variables).",
+    )
+    service_group.add_argument(
+        "--allowlist",
+        action="append",
+        metavar="DOMAIN[,DOMAIN...]",
+        help=(
+            "Allowed domains for crawling. Provide multiple times or comma-separated. "
+            f"Defaults to environment or {', '.join(_DEFAULT_ALLOWLIST)}."
+        ),
+    )
+    service_group.add_argument(
+        "--blocklist",
+        action="append",
+        metavar="DOMAIN[,DOMAIN...]",
+        help="Blocked domains for crawling. Provide multiple times or comma-separated.",
+    )
+    service_group.add_argument(
+        "--enable-network",
+        dest="enable_network",
+        action="store_true",
+        help="Allow outbound network requests for metasearch/crawling.",
+    )
+    service_group.add_argument(
+        "--disable-network",
+        dest="enable_network",
+        action="store_false",
+        help="Disable outbound network requests (default).",
+    )
+    service_group.add_argument(
+        "--use-playwright",
+        dest="use_playwright",
+        action="store_true",
+        help="Enable Playwright rendering when crawling (requires network access).",
+    )
+    service_group.add_argument(
+        "--no-playwright",
+        dest="use_playwright",
+        action="store_false",
+        help="Disable Playwright rendering (default).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse CLI arguments and start the uvicorn server."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.workers < 1:
+        parser.error("--workers must be >= 1")
+
+    allowlist = (
+        _split_domains(args.allowlist)
+        if args.allowlist
+        else _env_list("RESEARCH_MCP_ALLOWLIST", _DEFAULT_ALLOWLIST)
+    )
+    blocklist = (
+        _split_domains(args.blocklist)
+        if args.blocklist
+        else _env_list("RESEARCH_MCP_BLOCKLIST", ())
+    )
+    os.environ["RESEARCH_MCP_ALLOWLIST"] = _format_domains(allowlist)
+    os.environ["RESEARCH_MCP_BLOCKLIST"] = _format_domains(blocklist)
+    os.environ["RESEARCH_MCP_ENABLE_NETWORK"] = "1" if args.enable_network else "0"
+    os.environ["RESEARCH_MCP_USE_PLAYWRIGHT"] = "1" if args.use_playwright else "0"
+
+    uvicorn_kwargs: dict[str, Any] = {
+        "factory": True,
+        "host": args.host,
+        "port": args.port,
+        "reload": args.reload,
+        "log_level": args.log_level,
+        "proxy_headers": args.proxy_headers,
+    }
+
+    if args.root_path:
+        uvicorn_kwargs["root_path"] = args.root_path
+
+    if not args.reload and args.workers > 1:
+        uvicorn_kwargs["workers"] = args.workers
+
+    uvicorn.run("research_mcp.app:create_app", **uvicorn_kwargs)
+
+
+__all__ = ["build_parser", "main"]
+

--- a/packages/mcp-servers/research-mcp/tests/test_cli.py
+++ b/packages/mcp-servers/research-mcp/tests/test_cli.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from research_mcp import cli
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "RESEARCH_MCP_HOST",
+        "RESEARCH_MCP_PORT",
+        "RESEARCH_MCP_RELOAD",
+        "RESEARCH_MCP_LOG_LEVEL",
+        "RESEARCH_MCP_WORKERS",
+        "RESEARCH_MCP_PROXY_HEADERS",
+        "RESEARCH_MCP_ROOT_PATH",
+        "RESEARCH_MCP_ALLOWLIST",
+        "RESEARCH_MCP_BLOCKLIST",
+        "RESEARCH_MCP_ENABLE_NETWORK",
+        "RESEARCH_MCP_USE_PLAYWRIGHT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _capture_uvicorn(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_run(app: str, **kwargs: object) -> None:
+        captured["app"] = app
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+    return captured
+
+
+def test_main_invokes_uvicorn_with_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main([])
+
+    assert captured["app"] == "research_mcp.app:create_app"
+    kwargs = captured["kwargs"]
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 8081
+    assert kwargs["reload"] is False
+    assert kwargs["log_level"] == "info"
+    assert kwargs["proxy_headers"] is False
+    assert "workers" not in kwargs
+    assert "root_path" not in kwargs
+
+
+def test_cli_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main(
+        [
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9000",
+            "--reload",
+            "--log-level",
+            "debug",
+            "--workers",
+            "4",
+            "--proxy-headers",
+            "--root-path",
+            "/mcp",
+        ]
+    )
+
+    kwargs = captured["kwargs"]
+    assert kwargs["host"] == "127.0.0.1"
+    assert kwargs["port"] == 9000
+    assert kwargs["reload"] is True
+    assert kwargs["log_level"] == "debug"
+    assert kwargs["proxy_headers"] is True
+    assert kwargs["root_path"] == "/mcp"
+    # workers are ignored when reload is enabled
+    assert "workers" not in kwargs
+
+
+def test_cli_uses_environment_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("RESEARCH_MCP_HOST", "127.0.0.2")
+    monkeypatch.setenv("RESEARCH_MCP_PORT", "9100")
+    monkeypatch.setenv("RESEARCH_MCP_RELOAD", "true")
+    monkeypatch.setenv("RESEARCH_MCP_LOG_LEVEL", "warning")
+    monkeypatch.setenv("RESEARCH_MCP_WORKERS", "2")
+    monkeypatch.setenv("RESEARCH_MCP_PROXY_HEADERS", "1")
+    monkeypatch.setenv("RESEARCH_MCP_ROOT_PATH", "/prefix")
+    monkeypatch.setenv("RESEARCH_MCP_ALLOWLIST", "example.com,acme.com")
+    monkeypatch.setenv("RESEARCH_MCP_BLOCKLIST", "evil.invalid")
+    monkeypatch.setenv("RESEARCH_MCP_ENABLE_NETWORK", "1")
+    monkeypatch.setenv("RESEARCH_MCP_USE_PLAYWRIGHT", "1")
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main([])
+
+    kwargs = captured["kwargs"]
+    assert kwargs["host"] == "127.0.0.2"
+    assert kwargs["port"] == 9100
+    assert kwargs["reload"] is True
+    assert kwargs["log_level"] == "warning"
+    assert kwargs["proxy_headers"] is True
+    assert kwargs["root_path"] == "/prefix"
+    assert "workers" not in kwargs
+    assert os.environ["RESEARCH_MCP_ALLOWLIST"] == "example.com,acme.com"
+    assert os.environ["RESEARCH_MCP_BLOCKLIST"] == "evil.invalid"
+    assert os.environ["RESEARCH_MCP_ENABLE_NETWORK"] == "1"
+    assert os.environ["RESEARCH_MCP_USE_PLAYWRIGHT"] == "1"
+
+
+def test_cli_sets_workers_when_reload_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main(["--workers", "3", "--no-reload"])
+
+    kwargs = captured["kwargs"]
+    assert kwargs["reload"] is False
+    assert kwargs["workers"] == 3
+
+
+def test_cli_sets_service_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main(
+        [
+            "--allowlist",
+            "example.com",
+            "--allowlist",
+            "acme.com,news.example",
+            "--blocklist",
+            "tracker.example",
+            "--enable-network",
+            "--use-playwright",
+        ]
+    )
+
+    assert os.environ["RESEARCH_MCP_ALLOWLIST"] == "example.com,acme.com,news.example"
+    assert os.environ["RESEARCH_MCP_BLOCKLIST"] == "tracker.example"
+    assert os.environ["RESEARCH_MCP_ENABLE_NETWORK"] == "1"
+    assert os.environ["RESEARCH_MCP_USE_PLAYWRIGHT"] == "1"
+
+    kwargs = captured["kwargs"]
+    assert kwargs["proxy_headers"] is False
+
+
+def test_cli_can_disable_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("RESEARCH_MCP_ENABLE_NETWORK", "1")
+    monkeypatch.setenv("RESEARCH_MCP_USE_PLAYWRIGHT", "1")
+    captured = _capture_uvicorn(monkeypatch)
+
+    cli.main(["--disable-network", "--no-playwright"])
+
+    assert os.environ["RESEARCH_MCP_ENABLE_NETWORK"] == "0"
+    assert os.environ["RESEARCH_MCP_USE_PLAYWRIGHT"] == "0"
+
+    kwargs = captured["kwargs"]
+    assert kwargs["reload"] is False


### PR DESCRIPTION
## Summary
- add a reusable CLI module that wires uvicorn to the Research MCP FastAPI factory with configurable flags
- route the package entry points through the new CLI and document `python -m research_mcp` usage
- tighten crawler fallbacks to stay synthetic when Playwright is unavailable and add tests covering the CLI behaviour
- expose CLI flags for crawler allow/block lists and network/Playwright toggles with accompanying documentation and tests

## Testing
- PYTHONPATH=packages/mcp-servers/research-mcp/src pytest packages/mcp-servers/research-mcp/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d02d3dea488330ab4ec15237ba82c7