### PR TITLE
fix: organize API test imports

### DIFF
--- a/packages/api/tests/test_app_health.py
+++ b/packages/api/tests/test_app_health.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingImports=false
 from fastapi.testclient import TestClient
+
 from stratmaster_api.app import create_app
 
 

--- a/packages/api/tests/test_debug_config.py
+++ b/packages/api/tests/test_debug_config.py
@@ -3,6 +3,7 @@ import os
 from contextlib import contextmanager
 
 from fastapi.testclient import TestClient
+
 from stratmaster_api.app import create_app
 
 

--- a/packages/api/tests/test_endpoints.py
+++ b/packages/api/tests/test_endpoints.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from stratmaster_api.app import create_app
 
 IDEMPOTENCY_HEADERS = {"Idempotency-Key": "test-key-1234"}

--- a/packages/api/tests/test_openai_tool_schemas.py
+++ b/packages/api/tests/test_openai_tool_schemas.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+
 from stratmaster_api.app import create_app
 
 


### PR DESCRIPTION
## Summary
- organize API test import blocks to satisfy Ruff's I001 check

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d1b2a35d008330b88dff6ee776b9d8